### PR TITLE
Update windows target to .NET 8

### DIFF
--- a/PanCardView/PanCardView.csproj
+++ b/PanCardView/PanCardView.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net8.0-ios;net8.0-android;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
### Details
All other targets/frameworks were updated to .NET 8 excluding windows. Couldn't find anything in issues or commits to highlight if this was intentional or not.

Prior to updating the target, I was unable to build the solution for development on a windows machine.

### Tested Platforms
- Windows