### PR TITLE
Improvements to IndicatorsControl

### DIFF
--- a/PanCardView/Common/Controls/IndicatorsControl.cs
+++ b/PanCardView/Common/Controls/IndicatorsControl.cs
@@ -52,7 +52,10 @@ namespace PanCardView.Controls
             bindable.AsIndicatorsControl().ResetItemsSource(oldValue as IEnumerable);
         });
 
-        public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(IndicatorsControl), new DataTemplate(typeof(IndicatorItemView)));
+        public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(IndicatorsControl), new DataTemplate(typeof(IndicatorItemView)), propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            bindable.AsIndicatorsControl().ResetIndicatorsLayout();
+        });
 
         public static readonly BindableProperty UseParentAsBindingContextProperty = BindableProperty.Create(nameof(UseParentAsBindingContext), typeof(bool), typeof(IndicatorsControl), true);
 

--- a/PanCardView/PanCardView.csproj
+++ b/PanCardView/PanCardView.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net8.0-ios;net8.0-android;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/PanCardViewSample/PanCardViewSample/Common/App.xaml.cs
+++ b/PanCardViewSample/PanCardViewSample/Common/App.xaml.cs
@@ -56,6 +56,12 @@ namespace PanCardViewSample
                 this.Navigation.PushAsync(new CarouselSampleXamlView());
             };
 
+            var toCarouselIndicatorXamlBtn = new Button { Text = "CarouselView Indicator Xaml", FontSize = 20, TextColor = Colors.Black };
+            toCarouselIndicatorXamlBtn.Clicked += (sender, e) =>
+            {
+                this.Navigation.PushAsync(new CarouselSampleIndicatorXamlView());
+            };
+
             var toCarouselListBtn = new Button { Text = "Carousel ListView" };
             toCarouselListBtn.Clicked += (sender, e) =>
             {
@@ -83,6 +89,7 @@ namespace PanCardViewSample
                     Children = {
                         toCardsBtn,
                         toCarouselXamlBtn,
+                        toCarouselIndicatorXamlBtn,
                         toCoverFlowBtn,
                         toCubeBtn,
                         toCarouselNestedBtn,

--- a/PanCardViewSample/PanCardViewSample/Common/Views/CarouselSampleIndicatorXamlView.xaml
+++ b/PanCardViewSample/PanCardViewSample/Common/Views/CarouselSampleIndicatorXamlView.xaml
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    x:Class="PanCardViewSample.Views.CarouselSampleIndicatorXamlView"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:cards="clr-namespace:PanCardView;assembly=PanCardView"
+    xmlns:controls="clr-namespace:PanCardView.Controls;assembly=PanCardView"
+    xmlns:proc="clr-namespace:PanCardView.Processors;assembly=PanCardView"
+    xmlns:viewModels="clr-namespace:PanCardViewSample.ViewModels"
+    Title="Carousel Indicator Xaml"
+    BackgroundColor="Black">
+
+    <ContentPage.BindingContext>
+        <viewModels:CardsSampleViewModel />
+    </ContentPage.BindingContext>
+
+    <ContentPage.Resources>
+        <Style x:Key="SelectedIndicator" TargetType="Border">
+            <Setter Property="BackgroundColor" Value="Yellow" />
+        </Style>
+
+        <Style x:Key="UnselectedIndicator" TargetType="Border">
+            <Setter Property="BackgroundColor" Value="Black" />
+        </Style>
+    </ContentPage.Resources>
+
+    <Grid>
+        <cards:CarouselView
+            x:Name="Carousel"
+            Padding="50"
+            SelectedIndex="{Binding CurrentIndex}"
+            SlideShowDuration="3500">
+            <x:Arguments>
+                <proc:CarouselProcessor
+                    OpacityFactor="0"
+                    RotationFactor="0.1"
+                    ScaleFactor="0.5" />
+            </x:Arguments>
+
+            <cards:CarouselView.ItemsSource>
+                <x:Array Type="{x:Type View}">
+                    <BoxView Color="Red" />
+                    <BoxView Color="Green" />
+                    <BoxView Color="Blue" />
+                </x:Array>
+            </cards:CarouselView.ItemsSource>
+
+            <controls:IndicatorsControl
+                SelectedIndicatorStyle="{StaticResource SelectedIndicator}"
+                ToFadeDuration="1500"
+                UnselectedIndicatorStyle="{StaticResource UnselectedIndicator}">
+                <controls:IndicatorsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border
+                            HeightRequest="20"
+                            Stroke="White"
+                            StrokeShape="RoundRectangle 20,0,0,20"
+                            WidthRequest="20" />
+                    </DataTemplate>
+                </controls:IndicatorsControl.ItemTemplate>
+            </controls:IndicatorsControl>
+
+            <controls:LeftArrowControl ToFadeDuration="2500" />
+            <controls:RightArrowControl ToFadeDuration="2500" />
+        </cards:CarouselView>
+
+        <!--  NOTE: This is an example of setting up an IndicatorsControl that's not nested in the CarouselView  -->
+        <!--<controls:IndicatorsControl
+            BindingContext="{x:Reference Carousel}"
+            SelectedIndicatorStyle="{StaticResource SelectedIndicator}"
+            ToFadeDuration="1500"
+            UnselectedIndicatorStyle="{StaticResource UnselectedIndicator}"
+            UseParentAsBindingContext="False">
+            <controls:IndicatorsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border
+                        HeightRequest="20"
+                        Stroke="White"
+                        StrokeShape="RoundRectangle 20,0,0,20"
+                        WidthRequest="20" />
+                </DataTemplate>
+            </controls:IndicatorsControl.ItemTemplate>
+        </controls:IndicatorsControl>-->
+    </Grid>
+
+</ContentPage>

--- a/PanCardViewSample/PanCardViewSample/Common/Views/CarouselSampleIndicatorXamlView.xaml.cs
+++ b/PanCardViewSample/PanCardViewSample/Common/Views/CarouselSampleIndicatorXamlView.xaml.cs
@@ -3,9 +3,9 @@
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class CarouselSampleIndicatorXamlView : ContentPage
     {
-		public CarouselSampleIndicatorXamlView()
-		{
-			InitializeComponent();
+        public CarouselSampleIndicatorXamlView()
+        {
+                InitializeComponent();
         }
     }
 }

--- a/PanCardViewSample/PanCardViewSample/Common/Views/CarouselSampleIndicatorXamlView.xaml.cs
+++ b/PanCardViewSample/PanCardViewSample/Common/Views/CarouselSampleIndicatorXamlView.xaml.cs
@@ -1,0 +1,11 @@
+﻿namespace PanCardViewSample.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CarouselSampleIndicatorXamlView : ContentPage
+    {
+		public CarouselSampleIndicatorXamlView()
+		{
+			InitializeComponent();
+        }
+    }
+}

--- a/PanCardViewSample/PanCardViewSample/PanCardViewSample.csproj
+++ b/PanCardViewSample/PanCardViewSample/PanCardViewSample.csproj
@@ -54,13 +54,10 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <None Remove="Common\" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Folder Include="Common\" />
-	</ItemGroup>
-	<ItemGroup>
 	  <MauiXaml Update="Common\Views\CarouselSampleNestedXamlView.xaml">
+	    <SubType></SubType>
+	  </MauiXaml>
+	  <MauiXaml Update="Common\Views\CarouselSampleIndicatorXamlView.xaml">
 	    <SubType></SubType>
 	  </MauiXaml>
 	  <MauiXaml Update="Common\Views\CarouselSampleXamlView.xaml">


### PR DESCRIPTION
### Note
Includes changes from #26, review that one first please!

### Details
Updated IndicatorsControl to refresh layout if its DataTemplate is updated. This fixes edge cases I ran into where the control would render with the default ItemTemplate, then it would bind/set to the specified template, but the control didn't reflect the new template. 

Also added a sample page to give an example on how to setup an IndicatorsView with a custom ItemTemplate. Along with an example on how to link to an IndicatorsView to a Carousel/CardsView that is not a parent.

### Tested Platforms
- iOS
- Android
- Windows

