### PR TITLE
Fix changing an IndicatorItemView's size value.

### DIFF
--- a/PanCardView/Common/Controls/CircleFrame.cs
+++ b/PanCardView/Common/Controls/CircleFrame.cs
@@ -17,6 +17,10 @@ namespace PanCardView.Controls
             HorizontalOptions = LayoutOptions.Center;
             HasShadow = false;
             Padding = 0;
+
+            // NOTE: Default Size was set either by bindable property default or
+            // applied style which doesn't call property changed. Need to manually update.
+            OnSizeUpdated();
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/PanCardView/Common/Controls/CircleFrame.cs
+++ b/PanCardView/Common/Controls/CircleFrame.cs
@@ -6,7 +6,7 @@ namespace PanCardView.Controls
 {
     public class CircleFrame : Frame
     {
-        public static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(double), typeof(CircleFrame), 0.0, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(double), typeof(CircleFrame), 10.0, propertyChanged: (bindable, oldValue, newValue) =>
         {
             bindable.AsCircleFrame().OnSizeUpdated();
         });

--- a/PanCardView/Common/Controls/IndicatorItemView.cs
+++ b/PanCardView/Common/Controls/IndicatorItemView.cs
@@ -4,11 +4,6 @@ namespace PanCardView.Controls
 {
     public class IndicatorItemView : CircleFrame
     {
-        public IndicatorItemView()
-        {
-            Size = 10;
-        }
-
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new static void Preserve()
         {

--- a/PanCardViewSample/PanCardViewSample/Common/Views/CarouselSampleIndicatorXamlView.xaml
+++ b/PanCardViewSample/PanCardViewSample/Common/Views/CarouselSampleIndicatorXamlView.xaml
@@ -15,11 +15,19 @@
     </ContentPage.BindingContext>
 
     <ContentPage.Resources>
-        <Style x:Key="SelectedIndicator" TargetType="Border">
+        <Style x:Key="SelectedIndicator" TargetType="controls:IndicatorItemView">
+            <Setter Property="Size" Value="50" />
+        </Style>
+
+        <Style x:Key="UnselectedIndicator" TargetType="controls:IndicatorItemView">
+            <Setter Property="Size" Value="20" />
+        </Style>
+
+        <Style x:Key="SelectedBorderIndicator" TargetType="Border">
             <Setter Property="BackgroundColor" Value="Yellow" />
         </Style>
 
-        <Style x:Key="UnselectedIndicator" TargetType="Border">
+        <Style x:Key="UnselectedBorderIndicator" TargetType="Border">
             <Setter Property="BackgroundColor" Value="Black" />
         </Style>
     </ContentPage.Resources>
@@ -46,9 +54,9 @@
             </cards:CarouselView.ItemsSource>
 
             <controls:IndicatorsControl
-                SelectedIndicatorStyle="{StaticResource SelectedIndicator}"
+                SelectedIndicatorStyle="{StaticResource SelectedBorderIndicator}"
                 ToFadeDuration="1500"
-                UnselectedIndicatorStyle="{StaticResource UnselectedIndicator}">
+                UnselectedIndicatorStyle="{StaticResource UnselectedBorderIndicator}">
                 <controls:IndicatorsControl.ItemTemplate>
                     <DataTemplate>
                         <Border
@@ -60,6 +68,12 @@
                 </controls:IndicatorsControl.ItemTemplate>
             </controls:IndicatorsControl>
 
+            <!--  NOTE: Example of setting styles of default ItemTemplate  -->
+            <!--<controls:IndicatorsControl
+                SelectedIndicatorStyle="{StaticResource SelectedIndicator}"
+                ToFadeDuration="1500"
+                UnselectedIndicatorStyle="{StaticResource UnselectedIndicator}" />-->
+
             <controls:LeftArrowControl ToFadeDuration="2500" />
             <controls:RightArrowControl ToFadeDuration="2500" />
         </cards:CarouselView>
@@ -67,9 +81,9 @@
         <!--  NOTE: This is an example of setting up an IndicatorsControl that's not nested in the CarouselView  -->
         <!--<controls:IndicatorsControl
             BindingContext="{x:Reference Carousel}"
-            SelectedIndicatorStyle="{StaticResource SelectedIndicator}"
+            SelectedIndicatorStyle="{StaticResource SelectedBorderIndicator}"
             ToFadeDuration="1500"
-            UnselectedIndicatorStyle="{StaticResource UnselectedIndicator}"
+            UnselectedIndicatorStyle="{StaticResource UnselectedBorderIndicator}"
             UseParentAsBindingContext="False">
             <controls:IndicatorsControl.ItemTemplate>
                 <DataTemplate>


### PR DESCRIPTION
### Details
Due to the order in which style properties are applied to elements, along with issues with the **Frame** element, there's conflicts with the Size value being set on the **IndicatorItemView**. After testing, I found when the view is rendered, style will apply a default size value on the **CircleFrame** and then the constructor of the **IndicatorItemView** was overriding the size.

Due to this, if anyone was to set the size of an **IndicatorItemView** using the selected and unselected styles, the new size was not respected. For now, I've moved the default "set" of size to the BindableProperty creation and this seems to fix said issues.

However, the fact that the **IndicatorItemView** inherits a **Frame** causes the effective minimum size to be the following:

![image](https://github.com/AndreiMisiukevich/CardView.MAUI/assets/50737458/808301ce-c436-4286-9eff-5fcda937fd9d)
_Code implemented on the base **Frame** element._

This default value creator really causes issues with the whole order of style applied values, constructors, etc. It also behaves completely differently on iOS and Android. Android will not allow heights/widths smaller than the padding unless you set MinimumHeightRequest/MinimumWidthRequest but iOS doesn't care and will ignore the padding.

To address all of these issues further and in a way that will align with user expectations, please see my proposed changes for a future pull request that I'll make if advised/approved of.

### Tested Platforms
- iOS
- Android
- Windows

### Future Proposed Changes
Since the following proposal will alter **IndicatorItemView** pretty heavily and most likely be a breaking change/major update for end users, please read my suggestion and advise if I'm allowed to flesh out and develop said changes. If you're not keen on me making these changes, all good! Forget I suggested this :)

I propose we change **CircleFrame** to inherit from **Border** rather than **Frame** (so a **CircleBorder**). With this change, we'll need to update the docs and README but the benefits will only improve user experience. Making the switch will address the following:

1. Align with Microsoft [recommendations](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/frame?view=net-maui-8.0&viewFallbackFrom=net-maui-7.0):

> The [Frame](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.frame) class existed in Xamarin.Forms and is present in .NET MAUI for users who are migrating their apps from Xamarin.Forms to .NET MAUI. If you're building a new .NET MAUI app it's recommended to use [Border](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.border) instead, and to set shadows using the Shadow bindable property on [VisualElement](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.visualelement). For more information, see [Border](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/border?view=net-maui-8.0) and [Shadow](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/shadow?view=net-maui-8.0).

2. Allow complete control for users over the sizing of **IndicatorItemViews** without the strange default values, overhead (like shadow) and shenanigans introduced by the **Frame** element.

3. Remove the need for a CornerRadius property, as **Border** allows us to set StrokeShape as an ellipse.