### PR TITLE
Fix iOS & MacCatalyst Carousel artifact on back navigation

### DIFF
--- a/PanCardView/Common/CarouselView.cs
+++ b/PanCardView/Common/CarouselView.cs
@@ -14,7 +14,9 @@ namespace PanCardView
             // NOTE: For some reason setting this to True
             // Makes the view invisible on Android
             // Probably it's a MAUI bug
-            //IsClippedToBounds = true;
+            IsClippedToBounds = 
+                DeviceInfo.Platform == DevicePlatform.MacCatalyst || 
+                DeviceInfo.Platform == DevicePlatform.iOS;
         }
 
         protected override double DefaultMoveSizePercentage => .3;

--- a/PanCardView/Common/CarouselView.cs
+++ b/PanCardView/Common/CarouselView.cs
@@ -11,12 +11,7 @@ namespace PanCardView
 
         public CarouselView(IProcessor processor) : base(processor)
         {
-            // NOTE: For some reason setting this to True
-            // Makes the view invisible on Android
-            // Probably it's a MAUI bug
-            IsClippedToBounds = 
-                DeviceInfo.Platform == DevicePlatform.MacCatalyst || 
-                DeviceInfo.Platform == DevicePlatform.iOS;
+            IsClippedToBounds = true;
         }
 
         protected override double DefaultMoveSizePercentage => .3;


### PR DESCRIPTION
### Details
This PR addresses issue #31. Through testing I found that if `IsClippedToBounds` is not set to `True` on iOS and MacCatalyst the Carousel items that are translated off screen will be dragged back on screen on back due to how iOS/MacOS handles the page pop/push animations.

I opted to keep simple and just have `IsClippedToBounds` only set to true on the affected platforms (rather than all other than Android), just to keep our other platforms consistent with what's been in versions so far.

### Platforms Tested
- MacCatalyst
- iOS
- Android
- Windows
