### PR TITLE
Pause/Stop slideshow when CardsView not visible

### DIFF
--- a/PanCardView/Common/CardsView.cs
+++ b/PanCardView/Common/CardsView.cs
@@ -858,13 +858,12 @@ namespace PanCardView
             SelectedItem = GetItemByIndex(index);
         }
 
-        protected virtual async void AdjustSlideShow(bool? isForceStop = null)
+        protected virtual async void AdjustSlideShow(bool isForceStop = false)
         {
-            bool isNotVisible = !IsVisible || Opacity <= 0;
-            isForceStop ??= isNotVisible || IsUserInteractionRunning || IsAutoInteractionRunning;
+            isForceStop |= !IsVisible || Opacity <= 0 || IsUserInteractionRunning || IsAutoInteractionRunning;
 
             DisposeCancellationTokenSource(ref _slideShowTokenSource);
-            if (isForceStop.Value)
+            if (isForceStop)
             {
                 return;
             }
@@ -2073,7 +2072,7 @@ namespace PanCardView
         {
             base.OnPropertyChanged(name);
 
-            if (name.IgnoreCaseEquals(nameof(IsVisible)) || name.IgnoreCaseEquals(nameof(Opacity)))
+            if (name == IsVisibleProperty.PropertyName || name == OpacityProperty.PropertyName)
             {
                 AdjustSlideShow();
             }
@@ -2081,8 +2080,8 @@ namespace PanCardView
 
         private void OnUnloaded(object sender, System.EventArgs e)
         {
-            AdjustSlideShow(true);
             Unloaded -= OnUnloaded;
+            AdjustSlideShow(true);
             Handler?.DisconnectHandler();
         }
     }

--- a/PanCardView/Common/CardsView.cs
+++ b/PanCardView/Common/CardsView.cs
@@ -860,7 +860,7 @@ namespace PanCardView
 
         protected virtual async void AdjustSlideShow(bool isForceStop = false)
         {
-            isForceStop |= !IsVisible || Opacity <= 0 || IsUserInteractionRunning || IsAutoInteractionRunning;
+            isForceStop = isForceStop || !IsVisible || Opacity <= 0 || IsUserInteractionRunning || IsAutoInteractionRunning;
 
             DisposeCancellationTokenSource(ref _slideShowTokenSource);
             if (isForceStop)

--- a/PanCardView/Common/Extensions/CardViewExtensions.cs
+++ b/PanCardView/Common/Extensions/CardViewExtensions.cs
@@ -112,8 +112,5 @@ namespace PanCardView.Extensions
             }
             return searchIndex;
         }
-
-        public static bool IgnoreCaseEquals(this string valueA, string valueB)
-            => valueA.Equals(valueB, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PanCardView/Common/Extensions/CardViewExtensions.cs
+++ b/PanCardView/Common/Extensions/CardViewExtensions.cs
@@ -112,5 +112,8 @@ namespace PanCardView.Extensions
             }
             return searchIndex;
         }
+
+        public static bool IgnoreCaseEquals(this string valueA, string valueB)
+            => valueA.Equals(valueB, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PanCardView/Common/Processors/CarouselProcessor.cs
+++ b/PanCardView/Common/Processors/CarouselProcessor.cs
@@ -186,7 +186,7 @@ namespace PanCardView.Processors
                 return 0;
             }
 
-            double value = cardsView.IsHorizontalOrientation ? view.TranslationX : view.TranslationY;
+            var value = cardsView.IsHorizontalOrientation ? view.TranslationX : view.TranslationY;
 
             if (double.IsNaN(value))
             {

--- a/PanCardView/Common/Processors/CarouselProcessor.cs
+++ b/PanCardView/Common/Processors/CarouselProcessor.cs
@@ -185,7 +185,14 @@ namespace PanCardView.Processors
             {
                 return 0;
             }
-            var value = cardsView.IsHorizontalOrientation ? view.TranslationX : view.TranslationY;
+
+            double value = cardsView.IsHorizontalOrientation ? view.TranslationX : view.TranslationY;
+
+            if (double.IsNaN(value))
+            {
+                return 0;
+            }
+
             value += Sign(value) * cardsView.GetSize(view) * 0.5 * (1 - view.Scale);
             return value;
         }


### PR DESCRIPTION
### Description
This PR aims to address issue #33 and add more resource management for the `CardsView`. 

- A NaN check was implemented on the `CarouselProcessor` to combat the crash in the issue.
- `CardsView` slideshows are now stopped & resumed depending on the state of the `CardsView`'s visibility (through `IsVisible` and `Opacity`) to help prevent extra processing.
- The `CardsView`'s handler is now disconnected on view unload to help cleanup resources/memory (in alignment with [Microsoft's recommendations](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/handlers/create?view=net-maui-8.0#:~:text=the%20Video%20object.-,Native%20view%20cleanup,-Each%20platform%27s%20handler)).
- `CardsView` slideshows are now stopped on view unload/cleanup as I noticed that they were still processing when the view had been "destroyed". This should cleanup strong references that might have been preventing the [GC](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals) from collecting the view.

### Platforms Tested
- Android
- iOS
- Windows