### PR TITLE
Fix CardsView being "disposed" too early

### DIFF
--- a/PanCardView/Common/CardsView.cs
+++ b/PanCardView/Common/CardsView.cs
@@ -222,7 +222,14 @@ namespace PanCardView
         {
             Processor = processor;
             SetPanGesture();
+            Loaded += OnLoaded;
             Unloaded += OnUnloaded;
+        }
+
+        ~CardsView()
+        {
+            Loaded -= OnLoaded;
+            Unloaded -= OnUnloaded;
         }
 
         private bool ShouldIgnoreSetCurrentView { get; set; }
@@ -2078,11 +2085,14 @@ namespace PanCardView
             }
         }
 
+        private void OnLoaded(object sender, System.EventArgs e)
+        {
+            AdjustSlideShow();
+        }
+
         private void OnUnloaded(object sender, System.EventArgs e)
         {
-            Unloaded -= OnUnloaded;
             AdjustSlideShow(true);
-            Handler?.DisconnectHandler();
         }
     }
 }


### PR DESCRIPTION
### Description
This PR aims to address issue #35.

- The `CardsView`'s handler is no longer disconnected on view unload as the unload event is called with no regard to the navigation stack. Meaning that the view handler was being disconnected on push navigation and not page destruction like initially thought (this is a massive sore point with MAUI as seen [here](https://github.com/dotnet/maui/issues/7354)). Until MAUI handles view life cycle properly as proposed/planned [here](https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview7/dotnetmaui.md#new-handler-disconnect-policy), `CardsView` will not handle life cycle.
- To adjust for the previous change, `CardsView` slideshows are now instead stopped & resumed when the view is unloaded (navigated away from) and loaded (navigated to).

### Platforms Tested
- Android
- iOS
- Windows