### PR TITLE
Added a flag to prevent clearing the ViewPool when parent size changed

### DIFF
--- a/PanCardView/Common/CardsView.cs
+++ b/PanCardView/Common/CardsView.cs
@@ -813,7 +813,7 @@ namespace PanCardView
             RemoveUnprocessingChildren();
             Layout(new Rect(X, Y, Width, Height));
         }
-        
+
         protected virtual void SetupBackViews(int? index = null)
         {
             var realIndex = index ?? SelectedIndex;

--- a/PanCardView/Common/CardsView.cs
+++ b/PanCardView/Common/CardsView.cs
@@ -95,8 +95,6 @@ namespace PanCardView
 
         public static readonly BindableProperty IsViewReusingEnabledProperty = BindableProperty.Create(nameof(IsViewReusingEnabled), typeof(bool), typeof(CardsView), true);
 
-        public static readonly BindableProperty IsViewPoolClearedOnSizeChangedEnabledProperty = BindableProperty.Create(nameof(IsViewPoolClearedOnSizeChangedEnabled), typeof(bool), typeof(CardsView), true);
-        
         public static readonly BindableProperty UserInteractionDelayProperty = BindableProperty.Create(nameof(UserInteractionDelay), typeof(int), typeof(CardsView), 0);
 
         public static readonly BindableProperty IsUserInteractionInCourseProperty = BindableProperty.Create(nameof(IsUserInteractionInCourse), typeof(bool), typeof(CardsView), true);
@@ -430,12 +428,6 @@ namespace PanCardView
             set => SetValue(IsViewReusingEnabledProperty, value);
         }
 
-        public bool IsViewPoolClearedOnSizeChangedEnabled
-        {
-            get => (bool)GetValue(IsViewPoolClearedOnSizeChangedEnabledProperty);
-            set => SetValue(IsViewPoolClearedOnSizeChangedEnabledProperty, value);
-        }
-        
         public int UserInteractionDelay
         {
             get => (int)GetValue(UserInteractionDelayProperty);
@@ -814,7 +806,7 @@ namespace PanCardView
 
         protected virtual async void OnSizeChanged()
         {
-            if (CurrentView != null && ItemTemplate != null && IsViewPoolClearedOnSizeChangedEnabled)
+            if (CurrentView != null && ItemTemplate != null)
             {
                 var currentViewPair = _viewsPool.FirstOrDefault(p => p.Value.Contains(CurrentView));
                 if (!currentViewPair.Equals(default(KeyValuePair<object, List<View>>)))

--- a/PanCardView/Common/CardsView.cs
+++ b/PanCardView/Common/CardsView.cs
@@ -42,7 +42,9 @@ namespace PanCardView
 
         public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(CardsView), propertyChanged: (bindable, oldValue, newValue) =>
         {
-            bindable.AsCardsView().ForceRedrawViews();
+           var cardView = bindable.AsCardsView();
+            cardView.OnItemTemplateChanged();
+            cardView.ForceRedrawViews();
         });
 
         public static readonly BindableProperty BackViewsDepthProperty = BindableProperty.Create(nameof(BackViewsDepth), typeof(int), typeof(CardsView), defaultValueCreator: b => b.AsCardsView().DefaultBackViewsDepth, propertyChanged: (bindable, oldValue, newValue) =>
@@ -806,23 +808,12 @@ namespace PanCardView
 
         protected virtual async void OnSizeChanged()
         {
-            if (CurrentView != null && ItemTemplate != null)
-            {
-                var currentViewPair = _viewsPool.FirstOrDefault(p => p.Value.Contains(CurrentView));
-                if (!currentViewPair.Equals(default(KeyValuePair<object, List<View>>)))
-                {
-                    currentViewPair.Value.Clear();
-                    currentViewPair.Value.Add(CurrentView);
-                    _viewsPool.Clear();
-                    _viewsPool.Add(currentViewPair.Key, currentViewPair.Value);
-                }
-            }
             await Task.Delay(1);// Workaround for https://github.com/AndreiMisiukevich/CardView/issues/194
             ForceRedrawViews();
             RemoveUnprocessingChildren();
             Layout(new Rect(X, Y, Width, Height));
         }
-
+        
         protected virtual void SetupBackViews(int? index = null)
         {
             var realIndex = index ?? SelectedIndex;
@@ -1764,6 +1755,21 @@ namespace PanCardView
             }
 
             OnObservableCollectionChanged(oldCollection, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+
+        private void OnItemTemplateChanged()
+        {
+            if (CurrentView != null)
+            {
+                var currentViewPair = _viewsPool.FirstOrDefault(p => p.Value.Contains(CurrentView));
+                if (!currentViewPair.Equals(default(KeyValuePair<object, List<View>>)))
+                {
+                    currentViewPair.Value.Clear();
+                    currentViewPair.Value.Add(CurrentView);
+                    _viewsPool.Clear();
+                    _viewsPool.Add(currentViewPair.Key, currentViewPair.Value);
+                }
+            }
         }
 
         private void SetNewIndex()

--- a/PanCardView/Common/CardsView.cs
+++ b/PanCardView/Common/CardsView.cs
@@ -95,6 +95,8 @@ namespace PanCardView
 
         public static readonly BindableProperty IsViewReusingEnabledProperty = BindableProperty.Create(nameof(IsViewReusingEnabled), typeof(bool), typeof(CardsView), true);
 
+        public static readonly BindableProperty IsViewPoolClearedOnSizeChangedEnabledProperty = BindableProperty.Create(nameof(IsViewPoolClearedOnSizeChangedEnabled), typeof(bool), typeof(CardsView), true);
+        
         public static readonly BindableProperty UserInteractionDelayProperty = BindableProperty.Create(nameof(UserInteractionDelay), typeof(int), typeof(CardsView), 0);
 
         public static readonly BindableProperty IsUserInteractionInCourseProperty = BindableProperty.Create(nameof(IsUserInteractionInCourse), typeof(bool), typeof(CardsView), true);
@@ -428,6 +430,12 @@ namespace PanCardView
             set => SetValue(IsViewReusingEnabledProperty, value);
         }
 
+        public bool IsViewPoolClearedOnSizeChangedEnabled
+        {
+            get => (bool)GetValue(IsViewPoolClearedOnSizeChangedEnabledProperty);
+            set => SetValue(IsViewPoolClearedOnSizeChangedEnabledProperty, value);
+        }
+        
         public int UserInteractionDelay
         {
             get => (int)GetValue(UserInteractionDelayProperty);
@@ -806,7 +814,7 @@ namespace PanCardView
 
         protected virtual async void OnSizeChanged()
         {
-            if (CurrentView != null && ItemTemplate != null)
+            if (CurrentView != null && ItemTemplate != null && IsViewPoolClearedOnSizeChangedEnabled)
             {
                 var currentViewPair = _viewsPool.FirstOrDefault(p => p.Value.Contains(CurrentView));
                 if (!currentViewPair.Equals(default(KeyValuePair<object, List<View>>)))

--- a/docs/CardsView.md
+++ b/docs/CardsView.md
@@ -37,7 +37,6 @@ IsUserInteractionEnabled | `bool` | true | Determines if the control can be inte
 IsUserInteractionInCourse | `bool` | true | Determines if the control should forbid to start new interaction with card before previous ending.
 IsUserInteractionRunning | `bool` | false | Determines if the UserInteration is running, e.g., This is set to true in `OnTouchStarted()` and false in `OnTouchEnded()`.
 IsViewReusingEnabled | `bool` | true | Determines wether the control should try to retrieve view from the views pool or create an own view for certain item.
-IsViewPoolClearedOnSizeChangedEnabled | `bool` | true | Determines wether the control should clear the views pool when the CardView size changed.
 IsPanInteractionEnabled | `bool` | true | Determines wether the control should handle pan gesture events or it should handle only swipes.
 IsHorizontalOrientation | `bool` | true | Determines what is the orientation of the control.
 IsNextItemPanInteractionEnabled | `bool` | true | Determines wether next items are available for user interaction.

--- a/docs/CardsView.md
+++ b/docs/CardsView.md
@@ -37,6 +37,7 @@ IsUserInteractionEnabled | `bool` | true | Determines if the control can be inte
 IsUserInteractionInCourse | `bool` | true | Determines if the control should forbid to start new interaction with card before previous ending.
 IsUserInteractionRunning | `bool` | false | Determines if the UserInteration is running, e.g., This is set to true in `OnTouchStarted()` and false in `OnTouchEnded()`.
 IsViewReusingEnabled | `bool` | true | Determines wether the control should try to retrieve view from the views pool or create an own view for certain item.
+IsViewPoolClearedOnSizeChangedEnabled | `bool` | true | Determines wether the control should clear the views pool when the CardView size changed.
 IsPanInteractionEnabled | `bool` | true | Determines wether the control should handle pan gesture events or it should handle only swipes.
 IsHorizontalOrientation | `bool` | true | Determines what is the orientation of the control.
 IsNextItemPanInteractionEnabled | `bool` | true | Determines wether next items are available for user interaction.


### PR DESCRIPTION
Trying to fix issue:
#39 

To keep the behavior the same, I've put the default to true.